### PR TITLE
feat: add head-first-sql skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ This means skills compose: `skill-router` acts as an orchestrator that picks the
 | [design-patterns](./design-patterns/) | Apply and review GoF design patterns from *Head First Design Patterns* — creational, structural, and behavioral patterns |
 | [domain-driven-design](./domain-driven-design/) | Design and review software using patterns from Eric Evans' *Domain-Driven Design* — tactical and strategic patterns, and Ubiquitous Language |
 | [effective-python](./effective-python/) | Python best practices from Brett Slatkin's *Effective Python* (2nd Edition) — Pythonic thinking, functions, classes, concurrency, and testing |
+| [head-first-sql](./head-first-sql/) | Write and review SQL using practices from Lynn Beighley's *Head First SQL* — joins, aggregation, transactions, NULL handling, indexes, and query optimization |
 | [effective-java](./effective-java/) | Java best practices from Joshua Bloch's *Effective Java* (3rd Edition) — object creation, generics, enums, lambdas, and concurrency |
 | [effective-kotlin](./effective-kotlin/) | Best practices from Marcin Moskała's *Effective Kotlin* (2nd Ed) — safety, readability, reusability, and abstraction |
 | [kotlin-in-action](./kotlin-in-action/) | Practices from *Kotlin in Action* (2nd Ed) — functions, classes, lambdas, nullability, and coroutines |

--- a/head-first-sql/SKILL.md
+++ b/head-first-sql/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: head-first-sql
+description: >
+  Write and review SQL using best practices from Lynn Beighley's *Head First SQL*.
+  Use this skill when writing SELECT queries, JOIN operations, subqueries, indexes,
+  transactions, stored procedures, or optimizing slow queries. Trigger on phrases
+  like "SQL query", "write a query", "optimize SQL", "JOIN", "subquery", "index",
+  "transaction", "foreign key", "normalization", "GROUP BY", "HAVING", "stored
+  procedure", "SQL review", "query performance", "database schema", "primary key",
+  "NULL handling", "aggregate function", "SQL best practices", or "fix my SQL".
+---
+
+# Head First SQL Skill
+
+You are an expert SQL developer grounded in Lynn Beighley's *Head First SQL*.
+You help developers in two modes:
+
+1. **Query Writing** — Produce correct, readable, and efficient SQL
+2. **SQL Review** — Analyze existing SQL and recommend improvements
+
+## How to Decide Which Mode
+
+- If the user asks to *write*, *create*, *generate*, or *build* a query → **Query Writing**
+- If the user asks to *review*, *check*, *improve*, *optimize*, or *audit* SQL → **SQL Review**
+- If ambiguous, ask briefly which mode they prefer
+
+---
+
+## Mode 1: Query Writing
+
+When writing SQL, follow this process:
+
+### Step 1 — Understand the Data Model
+
+Ask (or infer from context):
+
+- **Tables involved** — What entities are being queried?
+- **Relationships** — One-to-many? Many-to-many? Are foreign keys defined?
+- **Cardinality** — Are there duplicates? Is DISTINCT needed?
+- **Filtering needs** — What conditions narrow the result set?
+- **Aggregation** — Does the user need counts, sums, or averages?
+
+### Step 2 — Choose the Right SQL Constructs
+
+| Goal | Construct to Use |
+|------|-----------------|
+| Combine rows from related tables | INNER JOIN, LEFT JOIN, RIGHT JOIN |
+| Filter rows | WHERE (before aggregation), HAVING (after aggregation) |
+| Eliminate duplicates | DISTINCT or GROUP BY |
+| Aggregate data | COUNT, SUM, AVG, MIN, MAX with GROUP BY |
+| Find rows with no match | LEFT JOIN + WHERE right_table.id IS NULL |
+| Conditional logic | CASE WHEN … THEN … ELSE … END |
+| Reuse a query result | Subquery in FROM (derived table) or WITH (CTE) |
+| Insert, update, delete safely | Transactions with BEGIN / COMMIT / ROLLBACK |
+
+### Step 3 — Write the SQL
+
+Apply these principles:
+
+- **Explicit column lists over SELECT \*** — Always name the columns you need; `SELECT *` hides the schema, breaks on column reorder, and retrieves unnecessary data
+- **Aliases for readability** — Use `AS` to give tables and computed columns clear names (`COUNT(*) AS order_count`)
+- **JOIN over subqueries when possible** — JOINs are usually more readable and better-optimized by the query planner
+- **Use INNER JOIN vs LEFT JOIN correctly** — INNER returns only matched rows; LEFT returns all left rows with NULLs for unmatched right rows
+- **Filter early with WHERE** — Push filtering conditions into WHERE before GROUP BY to reduce rows the database processes
+- **HAVING is for aggregated conditions only** — `WHERE status = 'active'` belongs in WHERE; `HAVING COUNT(*) > 5` belongs in HAVING
+- **NULL awareness** — NULL propagates in comparisons; use `IS NULL` / `IS NOT NULL`, never `= NULL`; use COALESCE for defaults
+- **Transactions for multi-step writes** — Wrap any sequence of INSERT/UPDATE/DELETE that must succeed or fail together in a transaction
+- **Meaningful constraint names** — Name foreign keys and indexes descriptively (`fk_orders_customer_id`, `idx_orders_created_at`)
+- **Normalization by default** — Avoid repeating data across rows; put repeated values in a lookup table
+
+### Query Writing Examples
+
+**Example 1 — Aggregation with filtering:**
+```
+User: "Show me total sales per product category, but only categories with more than 10 orders"
+
+Write:
+SELECT
+    c.name            AS category_name,
+    COUNT(o.id)       AS order_count,
+    SUM(oi.price)     AS total_revenue
+FROM categories c
+INNER JOIN products p  ON p.category_id = c.id
+INNER JOIN order_items oi ON oi.product_id = p.id
+INNER JOIN orders o   ON o.id = oi.order_id
+WHERE o.status = 'completed'
+GROUP BY c.id, c.name
+HAVING COUNT(o.id) > 10
+ORDER BY total_revenue DESC;
+```
+
+**Example 2 — Find unmatched rows (LEFT JOIN anti-join):**
+```
+User: "Find all customers who have never placed an order"
+
+Write:
+SELECT c.id, c.name, c.email
+FROM customers c
+LEFT JOIN orders o ON o.customer_id = c.id
+WHERE o.id IS NULL;
+```
+
+**Example 3 — Safe multi-step write with transaction:**
+```
+User: "Transfer $100 from account 1 to account 2"
+
+Write:
+BEGIN;
+
+UPDATE accounts
+SET balance = balance - 100
+WHERE id = 1 AND balance >= 100;
+
+UPDATE accounts
+SET balance = balance + 100
+WHERE id = 2;
+
+-- Only commit if both updates succeeded
+COMMIT;
+-- On error: ROLLBACK;
+```
+
+---
+
+## Mode 2: SQL Review
+
+When reviewing SQL, apply these categories systematically:
+
+### Review Process
+
+1. **Correctness** — Does the query return the right rows? Check JOIN conditions, NULL handling, and WHERE vs HAVING placement
+2. **Readability** — Are column and table names clear? Is formatting consistent? Are aliases meaningful?
+3. **Performance** — Are indexes likely used? Are there full-table scans, Cartesian products, or N+1 patterns?
+4. **Safety** — Are writes inside transactions? Is input sanitized (parameterized queries, not string concatenation)?
+5. **Normalization** — Is data repeated across rows where a lookup table would be better?
+6. **NULL correctness** — Are NULL comparisons using IS NULL / IS NOT NULL? Is COALESCE used where defaults are needed?
+
+### Review Output Format
+
+```
+## Summary
+One paragraph: what the query does, which tables it touches, overall assessment.
+
+## Strengths
+What the SQL does well.
+
+## Issues Found
+For each issue:
+- **What**: describe the problem
+- **Why it matters**: explain the correctness, performance, or safety risk
+- **Suggested fix**: concrete SQL change
+
+## Recommendations
+Priority-ordered list of improvements, most critical first.
+```
+
+### Common Anti-Patterns to Flag
+
+- **SELECT \*** — Retrieves all columns including unused ones; breaks when columns are added or reordered
+- **Implicit cross join** — Missing JOIN condition creates Cartesian product: `FROM orders, customers` without a WHERE linking them
+- **WHERE on aggregated column** — `WHERE COUNT(*) > 5` should be `HAVING COUNT(*) > 5`
+- **= NULL comparison** — `WHERE column = NULL` never matches; use `WHERE column IS NULL`
+- **Missing transaction** — Multiple INSERT/UPDATE/DELETE statements that must be atomic without BEGIN/COMMIT
+- **Non-sargable WHERE clause** — Wrapping an indexed column in a function prevents index use: `WHERE YEAR(created_at) = 2024` instead of `WHERE created_at >= '2024-01-01' AND created_at < '2025-01-01'`
+- **Unnecessary DISTINCT** — Using DISTINCT to fix a query that has bad JOIN logic instead of fixing the JOIN
+- **Subquery in SELECT clause** — A correlated subquery that runs once per row (`SELECT (SELECT COUNT(*) FROM orders WHERE customer_id = c.id) FROM customers`) is an N+1; rewrite with a LEFT JOIN and GROUP BY
+- **String-concatenated SQL** — Building queries with `'SELECT ... WHERE id = ' + userInput` is SQL injection; always use parameterized queries
+- **Over-normalized or under-normalized schema** — Splitting a single attribute across multiple columns, or storing comma-separated IDs in one column
+
+---
+
+## General Guidelines
+
+- Prefer explicit, readable SQL over clever one-liners. Future readers (including you) will thank you.
+- Test queries against small data sets before running against large tables.
+- Add an index on any column that frequently appears in WHERE, JOIN ON, or ORDER BY clauses.
+- Always ask: "What happens when this column is NULL?" and handle it explicitly.
+- For deep reference on SQL constructs, read `references/sql-patterns.md`.
+- For the review checklist, read `references/review-checklist.md`.

--- a/head-first-sql/evals/evals.json
+++ b/head-first-sql/evals/evals.json
@@ -1,0 +1,60 @@
+{
+  "evals": [
+    {
+      "id": "eval-01-null-comparison-and-select-star",
+      "prompt": "Review this SQL query:\n\n```sql\nSELECT *\nFROM employees\nWHERE manager_id = NULL\nAND department = 'Engineering';\n```",
+      "expectations": [
+        "Flags that `= NULL` never matches any rows — NULL comparisons must use `IS NULL` or `IS NOT NULL`, not `=` or `!=`",
+        "Flags `SELECT *` — explicit column names should be used instead to make the query self-documenting and resistant to schema changes",
+        "Suggests the corrected query: `SELECT id, name, email, department FROM employees WHERE manager_id IS NULL AND department = 'Engineering'`",
+        "Explains WHY `= NULL` fails: NULL represents an unknown value, so any comparison with NULL returns UNKNOWN (not TRUE or FALSE), causing the row to be filtered out"
+      ]
+    },
+    {
+      "id": "eval-02-where-vs-having-and-correlated-subquery",
+      "prompt": "Review this SQL query:\n\n```sql\nSELECT\n    customer_id,\n    COUNT(*) AS order_count\nFROM orders\nGROUP BY customer_id\nWHERE COUNT(*) > 5;\n```",
+      "expectations": [
+        "Flags that `WHERE COUNT(*) > 5` is invalid SQL — aggregate functions cannot appear in WHERE clauses because WHERE filters rows BEFORE aggregation happens",
+        "Explains the difference: WHERE filters individual rows before grouping; HAVING filters groups after aggregation",
+        "Suggests the corrected query using HAVING: `SELECT customer_id, COUNT(*) AS order_count FROM orders GROUP BY customer_id HAVING COUNT(*) > 5`",
+        "Notes that the query alias `order_count` is good practice — explicit aliases make result sets self-documenting"
+      ]
+    },
+    {
+      "id": "eval-03-implicit-cross-join-cartesian-product",
+      "prompt": "Review this SQL query:\n\n```sql\nSELECT orders.id, customers.name, orders.total\nFROM orders, customers\nWHERE orders.status = 'shipped';\n```",
+      "expectations": [
+        "Flags the implicit cross join: `FROM orders, customers` with no JOIN condition creates a Cartesian product — every order row is combined with every customer row, producing orders × customers rows",
+        "Explains that the query is missing the JOIN condition `orders.customer_id = customers.id`, so it returns incorrect results (each order repeated for every customer in the database)",
+        "Suggests the corrected query using explicit INNER JOIN: `SELECT o.id, c.name, o.total FROM orders o INNER JOIN customers c ON c.id = o.customer_id WHERE o.status = 'shipped'`",
+        "Notes the performance risk: Cartesian products on large tables can produce millions of rows and crash or freeze the database",
+        "Recommends using explicit JOIN … ON syntax instead of comma-separated tables in FROM"
+      ]
+    },
+    {
+      "id": "eval-04-transaction-for-multi-step-write",
+      "prompt": "Review this SQL for a bank transfer operation:\n\n```sql\nUPDATE accounts SET balance = balance - 500 WHERE id = 1;\nUPDATE accounts SET balance = balance + 500 WHERE id = 2;\n```",
+      "expectations": [
+        "Flags the missing transaction: these two UPDATE statements are not wrapped in BEGIN/COMMIT, so if the second UPDATE fails (connection drop, constraint violation, crash), account 1 loses $500 but account 2 never receives it — data is permanently inconsistent",
+        "Explains atomicity: a transaction guarantees that either both updates succeed (COMMIT) or neither takes effect (ROLLBACK)",
+        "Suggests wrapping in a transaction: `BEGIN; UPDATE accounts SET balance = balance - 500 WHERE id = 1; UPDATE accounts SET balance = balance + 500 WHERE id = 2; COMMIT;`",
+        "Notes that a check for sufficient balance before deducting should also be added (`WHERE id = 1 AND balance >= 500`) to prevent negative balances",
+        "Explains ROLLBACK: if any error occurs between BEGIN and COMMIT, the application should issue ROLLBACK to undo the partial changes"
+      ]
+    },
+    {
+      "id": "eval-05-well-written-query-recognition",
+      "prompt": "Review this SQL query:\n\n```sql\nSELECT\n    p.id          AS product_id,\n    p.name        AS product_name,\n    c.name        AS category_name,\n    COUNT(oi.id)  AS times_ordered,\n    SUM(oi.quantity * oi.unit_price) AS total_revenue\nFROM products p\nINNER JOIN categories c\n    ON c.id = p.category_id\nINNER JOIN order_items oi\n    ON oi.product_id = p.id\nINNER JOIN orders o\n    ON o.id = oi.order_id\n   AND o.status = 'completed'\nWHERE p.active = TRUE\nGROUP BY p.id, p.name, c.name\nHAVING SUM(oi.quantity * oi.unit_price) > 1000\nORDER BY total_revenue DESC\nLIMIT 20;\n```",
+      "expectations": [
+        "Recognizes this as a well-written SQL query and says so explicitly",
+        "Praises explicit column aliases (`product_id`, `category_name`, `total_revenue`) that make the result set self-documenting",
+        "Praises explicit INNER JOIN … ON syntax that clearly states the join relationships",
+        "Praises filtering inactive products in WHERE before aggregation (`WHERE p.active = TRUE`) — reduces rows processed by GROUP BY",
+        "Praises correct HAVING usage for the post-aggregation filter (`HAVING SUM(...) > 1000`)",
+        "Praises joining the status filter directly in the JOIN condition (`AND o.status = 'completed'`) which filters order_items early",
+        "Does NOT manufacture fake issues to have something to say",
+        "May offer optional suggestions (e.g., an index on `products.active` or `orders.status`, or using a CTE for readability) but clearly frames them as enhancements, not bugs"
+      ]
+    }
+  ]
+}

--- a/head-first-sql/examples/after.md
+++ b/head-first-sql/examples/after.md
@@ -1,0 +1,30 @@
+# After
+
+The same query rewritten with explicit JOINs, correct NULL handling, named columns, and the N+1 correlated subquery eliminated.
+
+```sql
+-- Get customers with at least one order, showing their order count and total spend
+SELECT
+    c.id              AS customer_id,
+    c.name            AS customer_name,
+    c.email,
+    COUNT(o.id)       AS order_count,
+    SUM(oi.price)     AS total_spend
+FROM customers c
+INNER JOIN orders o
+    ON o.customer_id = c.id
+   AND o.status IS NOT NULL        -- correct NULL check
+INNER JOIN order_items oi
+    ON oi.order_id = o.id
+GROUP BY c.id, c.name, c.email
+HAVING COUNT(o.id) > 0            -- filter after aggregation
+ORDER BY total_spend DESC;
+```
+
+Key improvements:
+- **Explicit column list** replaces `SELECT *` — callers see exactly what they get; adding a column to the table won't silently break this query
+- **INNER JOIN … ON** replaces implicit cross join — the relationship between tables is visible in the query structure
+- **`IS NOT NULL`** replaces `!= NULL` — NULL comparisons with `=` or `!=` always return unknown (not TRUE), so they silently drop rows; `IS NOT NULL` is correct
+- **JOIN + GROUP BY** replaces the correlated subquery — the database executes one scan instead of one subquery per row; performance scales linearly rather than quadratically
+- **HAVING COUNT(o.id) > 0** filters after aggregation — only customers with matched orders appear; this is equivalent logic to the original intent, done correctly
+- **Column aliases** (`customer_id`, `order_count`, `total_spend`) make the result set self-documenting for application code consuming it

--- a/head-first-sql/examples/before.md
+++ b/head-first-sql/examples/before.md
@@ -1,0 +1,23 @@
+# Before
+
+A SQL query with multiple issues: SELECT *, missing transaction, correlated subquery N+1, and incorrect NULL comparison.
+
+```sql
+-- Get all customers, their total orders, and flag customers with no phone
+SELECT *
+FROM customers, orders
+WHERE customers.id = orders.customer_id
+AND orders.status != NULL
+AND (
+    SELECT COUNT(*)
+    FROM order_items
+    WHERE order_items.order_id = orders.id
+) > 0;
+```
+
+Problems in this query:
+1. `SELECT *` — returns every column from both tables (including duplicates like `id`)
+2. Implicit cross join syntax (`FROM customers, orders`) — harder to read than explicit JOIN
+3. `!= NULL` — never matches any row; NULL comparisons require `IS NOT NULL`
+4. Correlated subquery in WHERE runs once per row — N+1 performance problem
+5. No transaction wrapping when this is used alongside writes

--- a/head-first-sql/references/review-checklist.md
+++ b/head-first-sql/references/review-checklist.md
@@ -1,0 +1,47 @@
+# SQL Review Checklist
+
+Use this checklist when reviewing SQL queries or schemas.
+
+## Correctness
+
+- [ ] Are JOIN conditions complete and correct? (No missing ON clause → no Cartesian product)
+- [ ] Is `IS NULL` / `IS NOT NULL` used instead of `= NULL` / `!= NULL`?
+- [ ] Is WHERE used for row-level filters and HAVING for aggregate filters?
+- [ ] Does the query handle NULLs correctly in aggregate functions? (COUNT(*) vs COUNT(column))
+- [ ] Are all columns in SELECT either in GROUP BY or inside an aggregate function?
+- [ ] Does LEFT JOIN logic correctly identify unmatched rows (check for `IS NULL` on right table's key)?
+- [ ] Are INNER JOIN vs LEFT JOIN vs RIGHT JOIN types correct for the intended result?
+- [ ] Does the query return distinct rows when duplicates are expected to be eliminated?
+
+## Readability
+
+- [ ] Are explicit column names used instead of `SELECT *`?
+- [ ] Are meaningful aliases given to tables (`c` for `customers`) and computed columns (`AS order_count`)?
+- [ ] Is explicit JOIN syntax used instead of comma-separated tables in FROM?
+- [ ] Is the query formatted consistently (indented, one clause per line)?
+- [ ] Are complex conditions broken across multiple lines for readability?
+
+## Performance
+
+- [ ] Are there full-table scans on large tables that an index could eliminate?
+- [ ] Are WHERE conditions on indexed columns written in a sargable form? (No function wrapping: use `WHERE created_at >= '2024-01-01'` not `WHERE YEAR(created_at) = 2024`)
+- [ ] Is there a correlated subquery that runs once per row? (Rewrite with JOIN + GROUP BY)
+- [ ] Is DISTINCT used as a band-aid for a bad JOIN? (Investigate the duplication source instead)
+- [ ] Are indexes present on columns used in JOIN ON, WHERE, and ORDER BY?
+- [ ] Is LIMIT used for result sets that don't need to return all rows?
+
+## Safety
+
+- [ ] Are multi-step writes (INSERT + UPDATE + DELETE sequences) wrapped in a transaction?
+- [ ] Is ROLLBACK logic present for error cases?
+- [ ] Are queries built with parameterized placeholders, not string concatenation?
+- [ ] Do DELETE / UPDATE statements have a WHERE clause? (Bare DELETE FROM table deletes all rows)
+
+## Schema Design
+
+- [ ] Is there a primary key on every table?
+- [ ] Are foreign key constraints defined to enforce referential integrity?
+- [ ] Is data normalized — no repeating groups, no comma-separated IDs in a single column?
+- [ ] Are column names clear and consistent (snake_case, singular nouns for entity columns)?
+- [ ] Are NOT NULL constraints used on columns that should never be empty?
+- [ ] Is COALESCE used to provide defaults for nullable columns in SELECT?

--- a/head-first-sql/references/sql-patterns.md
+++ b/head-first-sql/references/sql-patterns.md
@@ -1,0 +1,202 @@
+# SQL Patterns Reference
+
+Common patterns from *Head First SQL* organized by use case.
+
+## JOIN Patterns
+
+### INNER JOIN — Return only matched rows
+```sql
+SELECT o.id, c.name
+FROM orders o
+INNER JOIN customers c ON c.id = o.customer_id;
+```
+Use when: You only want rows that have a match in both tables.
+
+### LEFT JOIN — Keep all left rows, NULL for unmatched right
+```sql
+SELECT c.id, c.name, o.id AS order_id
+FROM customers c
+LEFT JOIN orders o ON o.customer_id = c.id;
+```
+Use when: You want all customers, even those with no orders (order_id will be NULL).
+
+### Anti-join — Find rows with NO match
+```sql
+SELECT c.id, c.name
+FROM customers c
+LEFT JOIN orders o ON o.customer_id = c.id
+WHERE o.id IS NULL;
+```
+Use when: You want customers who have NEVER placed an order.
+
+### Many-to-many JOIN through junction table
+```sql
+SELECT s.name AS student, c.title AS course
+FROM students s
+INNER JOIN enrollments e ON e.student_id = s.id
+INNER JOIN courses c ON c.id = e.course_id;
+```
+Use when: Two tables have a many-to-many relationship via a junction (bridge) table.
+
+---
+
+## Aggregation Patterns
+
+### Count rows per group
+```sql
+SELECT department, COUNT(*) AS headcount
+FROM employees
+GROUP BY department
+ORDER BY headcount DESC;
+```
+
+### Filter groups with HAVING
+```sql
+SELECT department, COUNT(*) AS headcount
+FROM employees
+WHERE active = TRUE          -- filter rows BEFORE grouping
+GROUP BY department
+HAVING COUNT(*) > 10         -- filter groups AFTER aggregation
+ORDER BY headcount DESC;
+```
+
+### Aggregate with JOIN
+```sql
+SELECT
+    c.name,
+    COUNT(o.id)  AS order_count,
+    SUM(o.total) AS lifetime_value
+FROM customers c
+LEFT JOIN orders o ON o.customer_id = c.id
+GROUP BY c.id, c.name;
+```
+
+---
+
+## NULL Handling Patterns
+
+### Correct NULL comparison
+```sql
+-- Wrong: = NULL never matches
+WHERE phone = NULL
+
+-- Correct
+WHERE phone IS NULL
+WHERE phone IS NOT NULL
+```
+
+### Default value for NULL
+```sql
+SELECT name, COALESCE(phone, 'N/A') AS phone
+FROM customers;
+```
+
+### NULL in aggregation
+```sql
+COUNT(*)         -- counts all rows including NULLs
+COUNT(phone)     -- counts only non-NULL phone values
+SUM(amount)      -- ignores NULL amounts
+AVG(rating)      -- ignores NULL ratings (denominator = non-NULL count)
+```
+
+---
+
+## Subquery Patterns
+
+### Derived table (subquery in FROM)
+```sql
+SELECT dept, avg_salary
+FROM (
+    SELECT department AS dept, AVG(salary) AS avg_salary
+    FROM employees
+    GROUP BY department
+) AS dept_averages
+WHERE avg_salary > 60000;
+```
+
+### CTE (Common Table Expression) — cleaner than nested subquery
+```sql
+WITH dept_averages AS (
+    SELECT department, AVG(salary) AS avg_salary
+    FROM employees
+    GROUP BY department
+)
+SELECT department, avg_salary
+FROM dept_averages
+WHERE avg_salary > 60000;
+```
+
+### IN subquery
+```sql
+SELECT name FROM customers
+WHERE id IN (
+    SELECT DISTINCT customer_id FROM orders WHERE total > 1000
+);
+```
+Prefer JOIN over IN subquery for large tables — JOINs are generally better optimized.
+
+---
+
+## Transaction Pattern
+
+```sql
+BEGIN;
+
+-- Step 1
+UPDATE accounts SET balance = balance - 100 WHERE id = 1 AND balance >= 100;
+
+-- Step 2
+UPDATE accounts SET balance = balance + 100 WHERE id = 2;
+
+-- Commit only if everything succeeded
+COMMIT;
+
+-- On error in application code: ROLLBACK;
+```
+
+---
+
+## Index Patterns
+
+### When to add an index
+- Columns in WHERE clauses on large tables
+- Columns in JOIN ON conditions
+- Columns in ORDER BY when LIMIT is used
+
+### Sargable vs non-sargable
+```sql
+-- Non-sargable: function on column prevents index use
+WHERE YEAR(created_at) = 2024
+WHERE UPPER(email) = 'TEST@EXAMPLE.COM'
+
+-- Sargable: index can be used
+WHERE created_at >= '2024-01-01' AND created_at < '2025-01-01'
+WHERE email = 'test@example.com'   -- store emails lowercased
+```
+
+---
+
+## Schema Design Patterns
+
+### Foreign key constraint
+```sql
+CREATE TABLE orders (
+    id          INT PRIMARY KEY AUTO_INCREMENT,
+    customer_id INT NOT NULL,
+    total       DECIMAL(10, 2) NOT NULL,
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (customer_id) REFERENCES customers(id)
+);
+```
+
+### Junction table for many-to-many
+```sql
+CREATE TABLE enrollments (
+    student_id INT NOT NULL,
+    course_id  INT NOT NULL,
+    enrolled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (student_id, course_id),
+    FOREIGN KEY (student_id) REFERENCES students(id),
+    FOREIGN KEY (course_id)  REFERENCES courses(id)
+);
+```

--- a/skill-router/references/skill-catalog.md
+++ b/skill-router/references/skill-catalog.md
@@ -56,6 +56,15 @@ All 17 skills in the `@booklib/skills` library with routing metadata.
 - **Works well with:** microservices-patterns (domain model + service boundaries), clean-code-reviewer (model + code quality)
 - **Conflicts with:** clean-code-reviewer (rich models vs small functions — DDD wins for model design; clean code wins for code review)
 
+## head-first-sql
+- **Source:** *Head First SQL* by Lynn Beighley
+- **Domain:** SQL query writing and review, relational databases
+- **Language:** SQL (any RDBMS — MySQL, PostgreSQL, SQLite, SQL Server)
+- **Trigger keywords:** "SQL query", "write a query", "optimize SQL", "JOIN", "subquery", "index", "transaction", "foreign key", "normalization", "GROUP BY", "HAVING", "stored procedure", "SQL review", "query performance", "database schema", "primary key", "NULL handling", "aggregate function", "SQL best practices", "fix my SQL"
+- **Anti-triggers:** NoSQL databases, ORMs (unless the underlying SQL is visible), non-database backend code
+- **Works well with:** data-pipelines (SQL queries + pipeline orchestration), data-intensive-patterns (SQL correctness + storage internals)
+- **Conflicts with:** data-intensive-patterns (head-first-sql for application-level SQL; data-intensive-patterns for storage engine internals and distributed transactions)
+
 ## effective-java
 - **Source:** *Effective Java* (3rd Edition) by Joshua Bloch
 - **Domain:** Java best practices and idioms


### PR DESCRIPTION
Adds a new skill packaging SQL best practices from Lynn Beighley's Head First SQL — covering query writing, JOINs, aggregation, transactions, NULL handling, indexes, and query optimization.

Includes SKILL.md, before/after examples, 5 evals, reference files (review-checklist.md and sql-patterns.md), README table entry, and skill-router catalog entry.

Closes #11